### PR TITLE
Add compass-based control for mobile

### DIFF
--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -10,6 +10,7 @@ GameObject:
   - 4: {fileID: 443488}
   - 114: {fileID: 11470368}
   - 114: {fileID: 11418636}
+  - 114: {fileID: 11435118}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -42,7 +43,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SoundList:
   - name: intros
-    clipList: []
+    clipList:
+    - {fileID: 8300000, guid: 4d182ac735ecb864d86e88e3eb854f48, type: 3}
+--- !u!114 &11435118
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 139724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d54ebe90e9c5b4df382d27a9ae9d1fb0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tankPersonController: {fileID: 0}
+  resetTimeout: 4
 --- !u!114 &11470368
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -122,7 +122,7 @@ GameObject:
   - 82: {fileID: 8250742}
   - 136: {fileID: 13618318}
   - 114: {fileID: 11413048}
-  - 114: {fileID: 11405448}
+  - 114: {fileID: 11415000}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -1049,19 +1049,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
---- !u!114 &11405448
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 155546}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 117af46ba613e40bbb25cbad62b425f6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  smooth: 2
-  tiltAngle: 90
 --- !u!114 &11408270
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1171,6 +1158,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aca53c79b9a6d48738e11469bd36b08a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &11415000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 155546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03caff65c6b0ed745b6dcd2fac3ea9c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &11424540

--- a/Assets/Scenes/EndCreditsRoom.unity
+++ b/Assets/Scenes/EndCreditsRoom.unity
@@ -124,6 +124,10 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 11435118, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
+      propertyPath: tankPersonController
+      value: 
+      objectReference: {fileID: 1278583587}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
   m_IsPrefabParent: 0
@@ -169,6 +173,12 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
   m_IsPrefabParent: 0
+--- !u!114 &1278583587 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11471578, guid: b200f519ba9b4614891a2f5fca1c388c,
+    type: 2}
+  m_PrefabInternal: {fileID: 1278583586}
+  m_Script: {fileID: 11500000, guid: fdf653a5df357ee4f965611e19690e60, type: 3}
 --- !u!1 &2028559187
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -348,10 +348,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 11418636, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
-      propertyPath: SoundList.Array.data[0].clipList.Array.size
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 443488, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -382,12 +378,12 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 443488, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 11418636, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
-      propertyPath: SoundList.Array.data[0].clipList.Array.data[0]
+    - target: {fileID: 11435118, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
+      propertyPath: tankPersonController
       value: 
-      objectReference: {fileID: 8300000, guid: 4d182ac735ecb864d86e88e3eb854f48, type: 3}
+      objectReference: {fileID: 1642788709}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
   m_IsPrefabParent: 0
@@ -421,117 +417,6 @@ Transform:
   - {fileID: 21778882}
   m_Father: {fileID: 1716426513}
   m_RootOrder: 3
---- !u!1001 &451743621
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22474958, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22376988, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_Camera
-      value: 
-      objectReference: {fileID: 575131230}
-    - target: {fileID: 11406474, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1642788705}
-    - target: {fileID: 11406474, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ResetOrientation
-      objectReference: {fileID: 0}
-    - target: {fileID: 11494314, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: tankPersonController
-      value: 
-      objectReference: {fileID: 1642788709}
-    - target: {fileID: 11494314, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: phoneOrientation
-      value: 
-      objectReference: {fileID: 1642788705}
-    - target: {fileID: 11462330, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8a347a6838ab24bec9cec32145380bb1, type: 2}
-  m_IsPrefabParent: 0
---- !u!20 &575131230 stripped
-Camera:
-  m_PrefabParentObject: {fileID: 2030038, guid: b200f519ba9b4614891a2f5fca1c388c,
-    type: 2}
-  m_PrefabInternal: {fileID: 1495249112}
 --- !u!1 &609575236
 GameObject:
   m_ObjectHideFlags: 0
@@ -1403,15 +1288,29 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 2030038, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 11405448, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
   m_IsPrefabParent: 0
---- !u!114 &1642788705 stripped
-MonoBehaviour:
-  m_PrefabParentObject: {fileID: 11405448, guid: b200f519ba9b4614891a2f5fca1c388c,
-    type: 2}
+--- !u!1 &1628697378 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 155546, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
   m_PrefabInternal: {fileID: 1495249112}
-  m_Script: {fileID: 11500000, guid: 117af46ba613e40bbb25cbad62b425f6, type: 3}
+--- !u!114 &1628697380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1628697378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03caff65c6b0ed745b6dcd2fac3ea9c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1642788709 stripped
 MonoBehaviour:
   m_PrefabParentObject: {fileID: 11471578, guid: b200f519ba9b4614891a2f5fca1c388c,

--- a/Assets/Scenes/StartRoom.unity
+++ b/Assets/Scenes/StartRoom.unity
@@ -249,6 +249,10 @@ Prefab:
       propertyPath: SoundList.Array.data[0].clipList.Array.data[0]
       value: 
       objectReference: {fileID: 8300000, guid: 62e9429c84a3235499e557b7cae67ac2, type: 3}
+    - target: {fileID: 11435118, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
+      propertyPath: tankPersonController
+      value: 
+      objectReference: {fileID: 1428306949}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f25f36d7a23a33c498e43961ca87eae9, type: 2}
   m_IsPrefabParent: 0
@@ -430,3 +434,9 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b200f519ba9b4614891a2f5fca1c388c, type: 2}
   m_IsPrefabParent: 0
+--- !u!114 &1428306949 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11471578, guid: b200f519ba9b4614891a2f5fca1c388c,
+    type: 2}
+  m_PrefabInternal: {fileID: 1428306948}
+  m_Script: {fileID: 11500000, guid: fdf653a5df357ee4f965611e19690e60, type: 3}

--- a/Assets/Scripts/CompassCam.cs
+++ b/Assets/Scripts/CompassCam.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+
+public class CompassCam : MonoBehaviour
+{
+    private bool compassEnabled;
+    private Compass compass;
+
+    private const float SmoothFactorCompass = 0.25f;
+    private const float SmoothThresholdCompass = 30.0f;
+    private float oldHeading;
+    private float compassSnoozeTime = 0.25f;
+    private float originalHeading;
+    private Quaternion counterInitialRotation = Quaternion.identity;
+
+    public void Awake() {
+        #if UNITY_ANDROID
+        compassEnabled = true;
+        #else
+        compassEnabled = false;
+        #endif
+
+        if (compassEnabled) {
+            compass = Input.compass;
+            compass.enabled = true;
+        } else {
+            #if UNITY_EDITOR
+            Debug.Log("NO COMPASS");
+            #endif
+        }
+
+        originalHeading = transform.rotation.eulerAngles.y;
+    }
+
+    public void Update ()
+    {
+        if (compassEnabled) {
+            // Compass returns 0 at start of game. Gotta wait for it to warm up before initial reading?
+            if (compassSnoozeTime > 0) {
+                compassSnoozeTime -= Time.deltaTime;
+                if (compassSnoozeTime <= 0) ResetOrientation();
+            }
+
+            var newHeading = compass.magneticHeading;
+            oldHeading = DampIt(oldHeading, newHeading);
+            transform.localRotation = Quaternion.Slerp(transform.localRotation, Quaternion.Euler(0, oldHeading, 0) * counterInitialRotation, Time.deltaTime * 8);
+        }
+    }
+
+    public void ResetOrientation() {
+        if (compassEnabled) {
+            var heading = compass.magneticHeading;
+            counterInitialRotation = Quaternion.Euler(0, originalHeading - heading, 0);
+        }
+    }
+
+    // http://stackoverflow.com/questions/4699417/android-compass-orientation-on-unreliable-low-pass-filter#6462517
+    private float DampIt(float oldCompass, float newCompass) {
+        if (Mathf.Abs(newCompass - oldCompass) < 180) {
+            if (Mathf.Abs(newCompass - oldCompass) > SmoothThresholdCompass) {
+                oldCompass = newCompass;
+            }
+            else {
+                oldCompass = oldCompass + SmoothFactorCompass * (newCompass - oldCompass);
+            }
+        }
+        else {
+            if (360.0 - Mathf.Abs(newCompass - oldCompass) > SmoothThresholdCompass) {
+                oldCompass = newCompass;
+            }
+            else {
+                if (oldCompass > newCompass) {
+                    oldCompass = (oldCompass + SmoothFactorCompass * ((360 + newCompass - oldCompass) % 360) + 360) % 360;
+                }
+                else {
+                    oldCompass = (oldCompass - SmoothFactorCompass * ((360 - newCompass + oldCompass) % 360) + 360) % 360;
+                }
+            }
+        }
+
+        return oldCompass;
+    }
+
+    // void OnGUI() {
+    //     var st = new GUIStyle();
+    //     st.fontSize = 48;
+    //     GUILayout.Label("raw compass heading: " + Input.compass.magneticHeading, st);
+    //     GUILayout.Label("oldHeading: " + oldHeading, st);
+    //     GUILayout.Label("originalHeading: " + originalHeading, st);
+    //  }
+
+}
+

--- a/Assets/Scripts/CompassCam.cs.meta
+++ b/Assets/Scripts/CompassCam.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 03caff65c6b0ed745b6dcd2fac3ea9c6
+timeCreated: 1455412991
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -23,12 +23,14 @@ public class GameManager : MonoBehaviour {
   void Awake() {
     GameManager._instance = this;
     gameState = new GameState();
+    Screen.sleepTimeout = SleepTimeout.NeverSleep;
   }
 
   void Start () {
     gameState.On("penalty", OnPenalty);
     gameState.On("nextlevel", OnNextLevel);
     gameState.On("replaylevel", OnReplayLevel);
+    gameState.On("restartgame", OnRestartGame);
 
     gameState.On("intro", _ => playerAudioOnly.TransitionTo(0.5f));
     gameState.On("win", _ => playerAudioOnly.TransitionTo(0.5f));
@@ -52,12 +54,6 @@ public class GameManager : MonoBehaviour {
     }
   }
 
-  // Reload current scene.
-  void OnReplayLevel(string oldState) {
-    Debug.Log("Reloading level for retry.");
-    SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
-  }
-
   void OnNextLevel(string oldState) {
     var scene = SceneManager.GetActiveScene();
     Debug.Log("Scene " + scene.buildIndex + " of " + SceneManager.sceneCount + " finished. Next level!");
@@ -70,4 +66,16 @@ public class GameManager : MonoBehaviour {
       SceneManager.LoadScene(scene.buildIndex + 1);
     }
   }
+
+  // Reload current scene.
+  void OnReplayLevel(string oldState) {
+    Debug.Log("Reloading level for retry.");
+    SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+  }
+
+  void OnRestartGame(string oldState) {
+    Debug.Log("Restarting game at scene 0");
+    SceneManager.LoadScene(0);
+  }
+
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -44,6 +44,11 @@ public class GameManager : MonoBehaviour {
       Debug.Log("Quit pressed!");
       Application.Quit();
     }
+
+    if (Input.GetKeyDown(KeyCode.R)) {
+      Debug.Log("R pressed!");
+      gameState.TransitionTo("restartgame");
+    }
   }
 
   void OnPenalty(string oldState) {
@@ -59,8 +64,14 @@ public class GameManager : MonoBehaviour {
     Debug.Log("Scene " + scene.buildIndex + " of " + SceneManager.sceneCount + " finished. Next level!");
     if (scene.buildIndex == SceneManager.sceneCountInBuildSettings - 1) {
       // Play "all done" sound? Credits?
-      Debug.Log("No more levels! Quitting!");
-      Application.Quit();
+      #if UNITY_ANDROID
+        // Loop to beginning of game on mobile.
+        Debug.Log("Restarting game from the top.");
+        SceneManager.LoadScene(0);
+      #else
+        Debug.Log("No more levels! Quitting!");
+        Application.Quit();
+      #endif
     } else {
       // Load the next scene per build order in Build Settings.
       SceneManager.LoadScene(scene.buildIndex + 1);

--- a/Assets/Scripts/GyroCam.cs
+++ b/Assets/Scripts/GyroCam.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+// Based on: http://forum.unity3d.com/threads/sharing-gyroscope-controlled-camera-on-iphone-4.98828/
+public class GyroCam : MonoBehaviour
+{
+    private bool gyroBool;
+    private Gyroscope gyro;
+    private Quaternion rotFix;
+
+    public void Start ()
+    {
+        Transform currentParent = transform.parent;
+        GameObject camParent = new GameObject ("GyroCamParent");
+        camParent.transform.position = transform.position;
+        transform.parent = camParent.transform;
+        GameObject camGrandparent = new GameObject ("GyroCamGrandParent");
+        camGrandparent.transform.position = transform.position;
+        camParent.transform.parent = camGrandparent.transform;
+        camGrandparent.transform.parent = currentParent;
+
+        #if UNITY_3_4
+        gyroBool = Input.isGyroAvailable;
+        #else
+        gyroBool = SystemInfo.supportsGyroscope;
+        #endif
+
+        if (gyroBool) {
+            gyro = Input.gyro;
+            gyro.enabled = true;
+
+            if (Screen.orientation == ScreenOrientation.LandscapeLeft) {
+                camParent.transform.eulerAngles = new Vector3 (90, 180, 0);
+            } else if (Screen.orientation == ScreenOrientation.Portrait) {
+                camParent.transform.eulerAngles = new Vector3 (90, 180, 0);
+            } else if (Screen.orientation == ScreenOrientation.PortraitUpsideDown) {
+                camParent.transform.eulerAngles = new Vector3 (90, 180, 0);
+            } else if (Screen.orientation == ScreenOrientation.LandscapeRight) {
+                camParent.transform.eulerAngles = new Vector3 (90, 180, 0);
+            } else {
+                camParent.transform.eulerAngles = new Vector3 (90, 180, 0);
+            }
+
+            if (Screen.orientation == ScreenOrientation.LandscapeLeft) {
+                rotFix = new Quaternion (0, 0, 1, 0);
+            } else if (Screen.orientation == ScreenOrientation.Portrait) {
+                rotFix = new Quaternion (0, 0, 1, 0);
+            } else if (Screen.orientation == ScreenOrientation.PortraitUpsideDown) {
+                rotFix = new Quaternion (0, 0, 1, 0);
+            } else if (Screen.orientation == ScreenOrientation.LandscapeRight) {
+                rotFix = new Quaternion (0, 0, 1, 0);
+            } else {
+                rotFix = new Quaternion (0, 0, 1, 0);
+            }
+
+            transform.localRotation = getQuatMap() * rotFix;
+        } else {
+            #if UNITY_EDITOR
+            print("NO GYRO");
+            #endif
+        }
+    }
+
+    public void Update ()
+    {
+        if (gyroBool) {
+            var quatMap = getQuatMap();
+            transform.localRotation = quatMap * rotFix;
+        }
+    }
+
+    private Quaternion getQuatMap() {
+        Quaternion quatMap;
+        #if UNITY_IPHONE
+            quatMap = gyro.attitude;
+        return quatMap;
+        #elif UNITY_ANDROID
+            quatMap = new Quaternion(gyro.attitude.x,gyro.attitude.y,gyro.attitude.z,gyro.attitude.w);
+        return quatMap;
+        #else
+        return Quaternion.identity;
+        #endif
+    }
+}
+

--- a/Assets/Scripts/GyroCam.cs.meta
+++ b/Assets/Scripts/GyroCam.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: db21a92461370864fb02b8cfe45eb908
+timeCreated: 1455264954
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PhoneButtonController.cs
+++ b/Assets/Scripts/PhoneButtonController.cs
@@ -4,33 +4,34 @@ using System.Collections;
 public class PhoneButtonController : MonoBehaviour {
 
   public UnityStandardAssets.Characters.FirstPerson.TankPersonController tankPersonController;
-  public PhoneOrientation phoneOrientation;
+  public float resetTimeout = 4f;
+  private float origResetTimeout;
+  private GameState gameState;
 
 #if UNITY_ANDROID
 
+  void Awake() {
+    origResetTimeout = resetTimeout;
+    gameState = GameManager.instance.gameState;
+  }
+
   void Update () {
+    // Touch to walk forward.
     if (Input.touchCount > 0) {
-      if(Input.GetTouch (0).position.x / Screen.width > 0.9f) {
-        // Get movement of the finger since last frame
-        //Vector2 touchDeltaPosition = Input.GetTouch(0).deltaPosition;
-        phoneOrientation.ResetOrientation();
-        // Move object across XY plane
-        //transform.Translate(-touchDeltaPosition.x * speed, -touchDeltaPosition.y * speed, 0)
-      } else {
-        tankPersonController.PushForward();
-      }
+      tankPersonController.PushForward();
     } else {
       tankPersonController.StopPushForward();
     }
-  }
 
-  void OnPointerDown() {
-    Debug.Log ("clicked");
-  }
-
-  void OnPointerUp() {
-    Debug.Log ("Up");
-
+    // Touch with 4+ fingers for `resetTimeout` seconds to restart the game.
+    if (Input.touchCount >= 4 && resetTimeout > 0) {
+      resetTimeout -= Time.deltaTime;
+      if (resetTimeout <= 0) {
+        gameState.TransitionTo("restartgame");
+      }
+    } else {
+      resetTimeout = origResetTimeout;
+    }
   }
 
 #endif


### PR DESCRIPTION
I was testing gyro control, and I couldn't find a way to get rid of drift. The gyro doesn't measure an absolute position, it relies on relative measurements over time.

So I converted it to read the compass instead, which should provide a fixed coordinate system for orientation. This seems to be much more stable. It does have a fair amount of jitter, but it's unnoticeable in the audio. It only manifests as a bit of a video twitch when the camera's turned on for testing.

This branch makes the mobile version of the game loop back to the beginning after the credits, for demo purposes.

It also adds the 'R' key to restart the game from the beginning on desktop builds.
